### PR TITLE
Fix: Anchored LogoTimes update with time:go

### DIFF
--- a/src/datatypes/LogoSchedule.scala
+++ b/src/datatypes/LogoSchedule.scala
@@ -187,6 +187,7 @@ class LogoSchedule extends ExtensionObject {
        -------------------------------------------------------------------------- */
     while (event != null && event.tick <= untilTick) { // iterates through scheduleTree
       event.agents match {
+        getTickCounter(extcontext).tick(event.tick-getTickCounter(extcontext).ticks)
         case null => // observer context
           val nvmContext: org.nlogo.nvm.Context = new org.nlogo.nvm.Context(
             extcontext.nvmContext.job,


### PR DESCRIPTION
Anchored LogoTime objects can be updated to reflect a change with each event. Provided the missing method for updating ticks.